### PR TITLE
Fixed loader.load() being called multiple times

### DIFF
--- a/src/services/maps-manager.ts
+++ b/src/services/maps-manager.ts
@@ -30,11 +30,13 @@ export class HereMapsManager {
 
   private _defaultLayers: any;
 
+  private _loadPromise: Promise<H.Map>;
+
   constructor(private loader: LazyMapsApiLoader) {
     // check browser location
     this.getBrowserLocation().then(noop);
     // preload map immediately
-    this.loader.load().then(noop);
+    this._loadPromise = this.loader.load();
   }
 
   public onApiLoad(): Promise<H.service.Platform> {
@@ -134,8 +136,8 @@ export class HereMapsManager {
     });
   }
 
-  public getMap(name: string): Promise<H.Map> {
-    return this.loader.load().then(() => this._maps.get(name) as H.Map);
+  public getMap(name: string): Promise<H.Map | undefined> {
+    return this._loadPromise.then(() => this._maps.get(name));
   }
 
   public addMap(name: string, map: H.Map): void {


### PR DESCRIPTION
@mjaric This is a pretty minor change. I create a loader promise on the object that is used to make sure it is loaded instead of loading the loader multiple times.

There might be a better way to fix this long-term but I don't have time to look through it more extensively at the moment.

I did provide a temporary workaround for the issue( #4) so if you would rather I take a deeper look when I get a chance just let me know.