### PR TITLE
Fix: error when center has undefined coordinates

### DIFF
--- a/src/directives/map.ts
+++ b/src/directives/map.ts
@@ -72,13 +72,20 @@ export class MapComponent implements OnDestroy, OnInit, AfterContentInit {
    */
   @Input()
   set center(value: GeoPoint) {
+    if (!value) {
+      return;
+    }
+    
+    const mapCenter = toLatLng(value);
+
     this._map.then(map => {
-      if (value) {
-        map.setCenter(toLatLng(value));
+        if (mapCenter.lat && mapCenter.lng) {
+          map.setCenter(toLatLng(value));
       }
     });
-
-    this._center = toLatLng(value);
+    
+    if (mapCenter.lat && mapCenter.lng)
+      this._center = toLatLng(value);
   }
   get center() {
     return this._center;

--- a/src/loaders/lazy-maps-api-loader.ts
+++ b/src/loaders/lazy-maps-api-loader.ts
@@ -117,8 +117,8 @@ export class LazyMapsApiLoader extends BaseMapsApiLoader {
     script.src = this.createModuleUrl(moduleName, 'js');
     script.async = true;
     script.defer = true;
-    script.addEventListener("error", onError);
-    script.addEventListener("load", onLoad);
+    script.addEventListener('error', onError);
+    script.addEventListener('load', onLoad);
 
     return script;
   }

--- a/src/services.ts
+++ b/src/services.ts
@@ -11,7 +11,7 @@ export {IZoomLevel};
 import {IAnimation} from './services/zoom-level.type';
 import {GeoPoint} from './interface/lat-lng';
 
-export {IAnimation}
+export {IAnimation};
 /**
  * The following list shows the approximate level of detail
  * you can expect to see at each zoom level


### PR DESCRIPTION
When the map center has undefined coordinates the HEREMaps API throws an error: 
`InvalidArgumentError: H.map.ViewModel#setCameraData (Argument #0 position)`

This is important especially when you load the coordinates from a get request and start out with an undefined object